### PR TITLE
Support for Vapor 1.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "SlackBot",
     dependencies: [
-      .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 0, minor: 18)
+      .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1)
     ],
     exclude: [
         "Images"

--- a/Sources/SlackMessage.swift
+++ b/Sources/SlackMessage.swift
@@ -13,13 +13,9 @@ struct SlackMessage {
 }
 
 extension SlackMessage: NodeRepresentable {
-    func makeNode() throws -> Node {
-        return try Node(node: [
-                "id": id,
-                "channel": channel,
-                "type": "message",
-                "text": text
-            ]
-        )
+    public func makeNode(context: Context) throws -> Node {
+        return try Node(node: ["id": id, "channel": channel,
+                               "type": "message",
+                               "text": text])
     }
 }


### PR DESCRIPTION
# What

Make it work with first major release of `Vapor`.
# Why

When this project started Vapor was really young. I'm currently using `slack-bot` in my team and I'd like to use it with latest major version of `Vapor`.
# How

I've updated the conformance to protocol `NodeRepresantable` as defined in current major release of `Vapor`.
