### PR TITLE
Updated Config with .commandLine option

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -4,7 +4,7 @@ import Vapor
 let VERSION = "0.3.0"
 setupClient()
 
-let config = try Config(prioritized: [.directory(root: workingDirectory + "Config/")])
+let config = try Config(prioritized: [.commandLine, .directory(root: workingDirectory + "Config/")])
 guard let token = config["bot-config", "token"]?.string else { throw BotError.missingConfig }
 
 let rtmResponse = try BasicClient.loadRealtimeApi(token: token)


### PR DESCRIPTION
The "Deploy to Heroku" button generates a build that crashes with:

fatal error: Error raised at top level: SlackBot.BotError.missingConfig: file /home/buildnode/disk2/workspace/oss-swift-3.0-package-linux-ubuntu-14_04/swift/stdlib/public/core/ErrorType.swift, line 184

This pull request adds .commandLine to Config and the error is not raised anymore.